### PR TITLE
Update react-server-dom-* and React packages to secure versions (CVE-2025-55182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "geist": "^1.3.1",
     "lucide-react": "^0.446.0",
     "nanoid": "^5.0.8",
-    "next": "15.3.0-canary.31",
+    "next": "15.6.0-canary.58",
     "next-auth": "5.0.0-beta.25",
     "next-themes": "^0.3.0",
     "orderedmap": "^2.1.1",


### PR DESCRIPTION
This PR automatically bumps react-server-dom-* and related react dependencies (react, react-dom) to secure versions in order to mitigate CVE-2025-55182 and related vulnerabilities.

For details on the security issue and upstream changes, see: https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components.

If you have customized these dependencies, please review the changes and test accordingly.